### PR TITLE
Update new oshimen to deal with Japan regulation

### DIFF
--- a/oshimen/oshimens.ts
+++ b/oshimen/oshimens.ts
@@ -110,4 +110,14 @@ export const oshimens: Oshimen[] = [
       'おまえら、佳凪きのちゃんのこと好きだろ？noteは読んだか？あれは読んだ方が良いぞ。',
     tweetId: '1847210316666741024',
   },
+    {
+    id: 'nanami',
+    name: '立花菜波',
+    emoji: '⛰️',
+    birthday: { month: 1, day: 30 },
+    shortDescription: 'ﾅﾅﾐﾁｬﾝ... ｶｯｺｲｲﾈ...',
+    description:
+      '所沢住んでる人はみん菜波推しです。',
+    tweetId: '1847210316666741024',
+  },
 ]

--- a/oshimen/oshimens.ts
+++ b/oshimen/oshimens.ts
@@ -118,6 +118,6 @@ export const oshimens: Oshimen[] = [
     shortDescription: 'ﾅﾅﾐﾁｬﾝ... ｶｯｺｲｲﾈ...',
     description:
       '所沢住んでる人はみん菜波推しです。',
-    tweetId: '1847210316666741024',
+    tweetId: '1057102208548823040',
   },
 ]

--- a/oshimen/oshimens.ts
+++ b/oshimen/oshimens.ts
@@ -116,7 +116,7 @@ export const oshimens: Oshimen[] = [
     emoji: '⛰️',
     birthday: { month: 1, day: 30 },
     shortDescription: 'ﾅﾅﾐﾁｬﾝ... ｶｯｺｲｲﾈ...',
-    description: '所沢住んでる人はみん菜波推しです。',
+    description: '所沢住んでる人はみんな菜波推しです。',
     tweetId: '1057102208548823040',
   },
 ]

--- a/oshimen/oshimens.ts
+++ b/oshimen/oshimens.ts
@@ -110,14 +110,13 @@ export const oshimens: Oshimen[] = [
       'おまえら、佳凪きのちゃんのこと好きだろ？noteは読んだか？あれは読んだ方が良いぞ。',
     tweetId: '1847210316666741024',
   },
-    {
+  {
     id: 'nanami',
     name: '立花菜波',
     emoji: '⛰️',
     birthday: { month: 1, day: 30 },
     shortDescription: 'ﾅﾅﾐﾁｬﾝ... ｶｯｺｲｲﾈ...',
-    description:
-      '所沢住んでる人はみん菜波推しです。',
+    description: '所沢住んでる人はみん菜波推しです。',
     tweetId: '1057102208548823040',
   },
 ]


### PR DESCRIPTION
As a new regulation effective from 2024-12-01, all Tokorozawa-shi resident should be nanami-oshi.
to deal with new regulation, code change has be done.