### PR TITLE
fix: downgrade next version to ^15.1 in package.json and yarn.lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@floating-ui/react": "^0.27.5",
     "@fluentui/react-components": "^9.61.2",
     "dayjs": "^1.11.13",
-    "next": "15.2.3",
+    "next": "^15.1",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-twitter-embed": "^4.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4443,7 +4443,7 @@ __metadata:
     dayjs: "npm:^1.11.13"
     eslint: "npm:^9.22.0"
     eslint-config-next: "npm:15.2.3"
-    next: "npm:15.2.3"
+    next: "npm:^15.1"
     prettier: "npm:^3.5.3"
     react: "npm:19.0.0"
     react-dom: "npm:19.0.0"
@@ -4470,7 +4470,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:15.2.3":
+"next@npm:^15.1":
   version: 15.2.3
   resolution: "next@npm:15.2.3"
   dependencies:


### PR DESCRIPTION
https://github.com/cloudflare/next-on-pages/issues/949

このエラーが起こるのでdowngradeする