### PR TITLE
feat: 久遠じゅりあを推しメンリストに追加

### DIFF
--- a/oshimen/oshimens.ts
+++ b/oshimen/oshimens.ts
@@ -172,4 +172,14 @@ export const oshimens: Oshimen[] = [
     tweetId: '1920084876067549251',
     type: 'idol',
   },
+  {
+    id: 'julia',
+    name: '久遠じゅりあ',
+    emoji: '🍺',
+    birthday: { month: 12, day: 4 },
+    shortDescription: 'じゅちゃん... かわいいね...',
+    description: 'たまに出る広島弁が可愛すぎて横転です。',
+    tweetId: '1925870820896702830',
+    type: 'idol',
+  },
 ]


### PR DESCRIPTION
久遠じゅりあちゃんを推しメンリストに追加しました🍺

## 追加内容
- **名前**: 久遠じゅりあ
- **絵文字**: 🍺 (ビール)
- **誕生日**: 12月4日
- **短い説明**: じゅちゃん... かわいいね...
- **詳細説明**: たまに出る広島弁が可愛すぎて横転です。
- **ツイートID**: 1925870820896702830
- **タイプ**: idol

## 変更ファイル
-  - 久遠じゅりあのエントリを追加

広島弁がかわいすぎて推さざるを得ない🍺✨