### PR TITLE
feat: added 義理の妹

### DIFF
--- a/oshimen/oshimens.ts
+++ b/oshimen/oshimens.ts
@@ -282,4 +282,16 @@ export const oshimens: Oshimen[] = [
     type: 'idol',
     omoideCount: 5,
   },
+  {
+    id: 'yukine_tnla',
+    name: 'ユキネ',
+    emoji: '❄️',
+    birthday: { month: 12, day: 14 },
+    shortDescription: 'ﾕｷﾈﾁｬﾝ...ｵﾈｴﾁｬﾝと結婚したら義妹にしてあげるね...',
+    description:
+      '「はじめまして。先日オタクにチェキを代行してもらったもやしキングです。お姉ちゃんから来ました。」',
+    tweetId: '1999128277999665378',
+    type: 'idol',
+    omoideCount: 3,
+  },
 ]


### PR DESCRIPTION
# Tips


>  グループ名は、英語で「音色」や「色合い」を意味する"tonal"に、英語やラテン語由来で「国名」や「地名」を表す接尾辞"-ia"を組み合わせた造語であり、掲げるコンセプトを表現している。
> https://www.tunecore.co.jp/artists/tonalia_jp

"Oshimenia"は、各アイドルを「地名」に見たてることで、DD(Daredemo Daisuki)オタクに推しメンが多い「おしめえ」な状態を表す造語であり、DDの成れの果てを表現している。